### PR TITLE
Fix the MODE command for channels

### DIFF
--- a/src/lib/class/Server/command/invite.cpp
+++ b/src/lib/class/Server/command/invite.cpp
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/01 17:27:28 by jodufour          #+#    #+#             */
-/*   Updated: 2024/03/14 00:14:58 by jodufour         ###   ########.fr       */
+/*   Updated: 2024/03/15 12:54:05 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,6 @@ void Server::_invite(Client &sender, CommandParameterVector const &parameters)
 	if (parameters.size() < 2)
 		return sender.append_formatted_reply_to_msg_out(ERR_NEEDMOREPARAMS, "INVITE");
 
-	NickName const           &sender_nickname = sender.get_nickname();
 	NickName const           &target_nickname = parameters[0];
 	ClientMap::iterator const user_by_nickname = this->_clients_by_nickname.find(target_nickname);
 
@@ -51,7 +50,7 @@ void Server::_invite(Client &sender, CommandParameterVector const &parameters)
 	bool const            is_sender_operator = channel_modes.has_operator(sender);
 
 	if (channel_modes.is_set(InviteOnly) && !is_sender_operator)
-		return sender.append_formatted_reply_to_msg_out(ERR_CHANOPRIVSNEEDED, &sender_nickname);
+		return sender.append_formatted_reply_to_msg_out(ERR_CHANOPRIVSNEEDED, &channel_name);
 
 	Client::Modes const &target_modes = target.get_modes();
 

--- a/src/lib/class/Server/command/notice.cpp
+++ b/src/lib/class/Server/command/notice.cpp
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/01 17:28:18 by jodufour          #+#    #+#             */
-/*   Updated: 2024/03/15 06:34:35 by jodufour         ###   ########.fr       */
+/*   Updated: 2024/03/15 12:40:37 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,10 +29,14 @@ inline static void notice_to_channel(
 	Channel const     &target,
 	std::string const &msg)
 {
-	if (target.get_modes().is_set(NoMessagesFromOutside) && !target.has_member(sender))
+	bool const sender_is_member = target.has_member(sender);
+
+	if (target.get_modes().is_set(NoMessagesFromOutside) && sender_is_member)
 		return;
 
-	target.broadcast_to_all_members_but_one(sender.prefix() + "NOTICE " + target_name + " :" + msg, sender);
+	sender_is_member
+		? target.broadcast_to_all_members_but_one(sender.prefix() + "NOTICE " + target_name + " :" + msg, sender)
+		: target.broadcast_to_all_members(sender.prefix() + "NOTICE " + target_name + " :" + msg);
 }
 
 void Server::_notice(Client &sender, CommandParameterVector const &parameters)

--- a/src/lib/class/Server/command/privmsg.cpp
+++ b/src/lib/class/Server/command/privmsg.cpp
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/01 17:27:52 by jodufour          #+#    #+#             */
-/*   Updated: 2024/03/14 23:24:47 by jodufour         ###   ########.fr       */
+/*   Updated: 2024/03/15 12:39:10 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,10 +29,14 @@ inline static void privmsg_to_channel(
 	Channel const     &target,
 	std::string const &msg)
 {
-	if (target.get_modes().is_set(NoMessagesFromOutside) && !target.has_member(sender))
+	bool const sender_is_member(target.has_member(sender));
+
+	if (target.get_modes().is_set(NoMessagesFromOutside) && !sender_is_member)
 		return sender.append_formatted_reply_to_msg_out(ERR_CANNOTSENDTOCHAN, &target_name);
 
-	target.broadcast_to_all_members_but_one(sender.prefix() + "PRIVMSG " + target_name + " :" + msg, sender);
+	sender_is_member
+		? target.broadcast_to_all_members_but_one(sender.prefix() + "PRIVMSG " + target_name + " :" + msg, sender)
+		: target.broadcast_to_all_members(sender.prefix() + "PRIVMSG " + target_name + " :" + msg);
 }
 
 // TODO: Write the doxygen comment of this function

--- a/src/lib/class/Server/command/topic.cpp
+++ b/src/lib/class/Server/command/topic.cpp
@@ -6,32 +6,32 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/01 17:26:47 by jodufour          #+#    #+#             */
-/*   Updated: 2024/03/14 00:13:37 by jodufour         ###   ########.fr       */
+/*   Updated: 2024/03/15 12:53:06 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "class/Server.hpp"
 #include "replies.hpp"
 
-inline static void set_topic(Client &sender, Channel &channel, ChannelName const &chan_name, Topic const &topic)
+inline static void set_topic(Client &sender, Channel &channel, ChannelName const &channel_name, Topic const &topic)
 {
 	Channel::Modes const &modes = channel.get_modes();
 
 	if (modes.is_set(RestrictedTopic) && !modes.has_operator(sender))
-		return sender.append_formatted_reply_to_msg_out(ERR_CHANOPRIVSNEEDED, &sender.get_nickname());
+		return sender.append_formatted_reply_to_msg_out(ERR_CHANOPRIVSNEEDED, &channel_name);
 
 	channel.set_topic(topic.is_valid() ? topic : Topic());
-	channel.broadcast_to_all_members(sender.prefix() + "TOPIC " + chan_name + " :" + channel.get_topic());
+	channel.broadcast_to_all_members(sender.prefix() + "TOPIC " + channel_name + " :" + channel.get_topic());
 }
 
-inline static void send_back_current_topic(Client &sender, Channel const &channel, ChannelName const &chan_name)
+inline static void send_back_current_topic(Client &sender, Channel const &channel, ChannelName const &channel_name)
 {
 	Topic const &topic = channel.get_topic();
 
 	if (topic.empty())
-		return sender.append_formatted_reply_to_msg_out(RPL_NOTOPIC, &chan_name);
+		return sender.append_formatted_reply_to_msg_out(RPL_NOTOPIC, &channel_name);
 
-	sender.append_formatted_reply_to_msg_out(RPL_TOPIC, &chan_name, &topic);
+	sender.append_formatted_reply_to_msg_out(RPL_TOPIC, &channel_name, &topic);
 }
 
 void Server::_topic(Client &sender, CommandParameterVector const &parameters)


### PR DESCRIPTION
Related to #35.
The problem was that the `Channel::Modes::set` method calls didn't provide the additional argument while it is assumed to be present for some specific modes. Typically, everywhere we did:
```c++
modes_to_be[Cleared].set(KeyProtected);
```
or
```c++
modes_to_be[Cleared].set(Limit);
```
Also, I have fixed the `-k` mode change to require an argument, which must match the current key of the channel if any is set.
Finally, I made the `-l` mode change to require an argument too, which must match the current member limit of the channel if any is set.